### PR TITLE
Upgrade jenkins to 2.361 for pom major update (requires java 11 due to kenkins 2.361)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,18 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        jdk: [11, 17]
 
     runs-on: ${{ matrix.platform }}
-    name: on ${{ matrix.platform }}
+    name: on ${{ matrix.platform }} with JDK ${{ matrix.jdk }}
 
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: ${{ matrix.jdk }}
       - name: Cache local Maven repository
         uses: actions/cache@v3.0.11
         with:
@@ -33,4 +34,4 @@ jobs:
       - name: Build with Maven
         env:
           BROWSER: chrome-container
-        run: mvn -V -ntp clean verify --file pom.xml '-Djenkins.test.timeout=5000' '-Dgpg.skip'
+        run: mvn -V --color always -ntp clean verify --file pom.xml '-Djenkins.test.timeout=5000' '-Dgpg.skip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,16 @@ jobs:
     name: on ${{ matrix.platform }} with JDK ${{ matrix.jdk }}
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
-      - name: Cache local Maven repository
-        uses: actions/cache@v3.0.11
+          check-latest: true
+          cache: 'maven'
+      - name: Cache dependencies
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,12 @@
-/*
- See the documentation for more options:
- https://github.com/jenkins-infra/pipeline-library/
-*/
-buildPlugin(useContainerAgent: true)
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(
+  // Container agents start faster and are easier to administer
+  useContainerAgent: true,
+  // Test Java 11 with default Jenkins version
+  configurations: [
+    [platform: 'linux',   jdk: '11'],
+    [platform: 'windows', jdk: '11']
+  ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <revision>5.2.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.baseline>2.346</jenkins.baseline>
+        <jenkins.baseline>2.361</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <java.level>11</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did : Update jenkins ci.yml to use java 11 (java 8 is used by default). Require jenkins 2.361 minimal version
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
