### PR TITLE
pom.xml: bump plugin-parent and bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.66</version>
+        <version>4.68</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>2163.v2d916d90c305</version>
+                <version>2198.v39c76fc308ca</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
After recent updates and restart of the Jenkins controller, our jobs began failing with post-processing:
````
Error when executing always post condition:
java.lang.ClassNotFoundException: org.eclipse.collections.impl.factory.Sets
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:35)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:587)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	at io.jenkins.plugins.reporter.steps.PublishReportStep$Descriptor.getRequiredContext(PublishReportStep.java:117)
...
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: e97f9fd3-2730-4261-8c7f-43fe43486b35
Caused: java.lang.NoClassDefFoundError: org/eclipse/collections/impl/factory/Sets
	at io.jenkins.plugins.reporter.steps.PublishReportStep$Descriptor.getRequiredContext(PublishReportStep.java:117)
...
````

After some discussion on Jenkins Gitter thread : https://matrix.to/#/!ouJVNKRtaWHFflDvBW:gitter.im/$yuB2vuyrvhG7R1WfNz2GMvvWQH4Hr7dO7SIK6T4pQx8?via=gitter.im&via=matrix.org&via=minds.com I tried to use a custom build of the plugin to ensure that it relies on newer jenkins-bom (maybe its updates in core deprecated something the plugin binary relied on?) and the problem went away ;)