### PR TITLE
remove dependency to eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <jenkins.baseline>2.492</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <jackson-dataformat.version>2.18.3</jackson-dataformat.version>
-        <eclipse-collections.version>11.1.0</eclipse-collections.version>
     </properties>
     
     <groupId>io.jenkins.plugins</groupId>
@@ -106,10 +105,6 @@
             <artifactId>data-tables-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>echarts-api</artifactId>
         </dependency>
@@ -122,17 +117,7 @@
             <artifactId>jackson-dataformat-csv</artifactId>
             <version>${jackson-dataformat.version}</version>
         </dependency>
-        <!-- Project Library Dependencies -->
-        <dependency>
-          <groupId>org.eclipse.collections</groupId>
-          <artifactId>eclipse-collections-api</artifactId>
-          <version>${eclipse-collections.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.eclipse.collections</groupId>
-          <artifactId>eclipse-collections</artifactId>
-          <version>${eclipse-collections.version}</version>
-        </dependency>
+
         <!-- Workflow dependencies -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/io/jenkins/plugins/reporter/ReportDetails.java
+++ b/src/main/java/io/jenkins/plugins/reporter/ReportDetails.java
@@ -65,8 +65,8 @@ public class ReportDetails implements ModelObject {
         this.item = item;
         this.displayName = displayName;
 
-        infoMessages.addAll(result.getInfoMessages().castToList());
-        errorMessages.addAll(result.getErrorMessages().castToList());
+        infoMessages.addAll(result.getInfoMessages());
+        errorMessages.addAll(result.getErrorMessages());
     }
 
     ReportResult getResult() {

--- a/src/main/java/io/jenkins/plugins/reporter/ReportResult.java
+++ b/src/main/java/io/jenkins/plugins/reporter/ReportResult.java
@@ -2,8 +2,7 @@ package io.jenkins.plugins.reporter;
 
 import hudson.model.Run;
 import io.jenkins.plugins.reporter.model.Report;
-import org.eclipse.collections.api.list.ImmutableList;
-import org.eclipse.collections.impl.factory.Lists;
+import java.util.Collections;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -46,11 +45,11 @@ public class ReportResult implements Serializable {
         return report;
     }
     
-    public ImmutableList<String> getErrorMessages() {
-        return Lists.immutable.withAll(errors);
+    public List<String> getErrorMessages() {
+        return Collections.unmodifiableList(errors);
     }
     
-    public ImmutableList<String> getInfoMessages() {
-        return Lists.immutable.withAll(messages);
+    public List<String> getInfoMessages() {
+        return Collections.unmodifiableList(messages);
     }
 }

--- a/src/main/java/io/jenkins/plugins/reporter/steps/PublishReportStep.java
+++ b/src/main/java/io/jenkins/plugins/reporter/steps/PublishReportStep.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.reporter.steps;
 
+import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
@@ -17,7 +18,6 @@ import io.jenkins.plugins.reporter.model.Provider;
 import io.jenkins.plugins.util.JenkinsFacade;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.collections.impl.factory.Sets;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.*;
 import org.kohsuke.stapler.AncestorInPath;
@@ -114,7 +114,7 @@ public class PublishReportStep extends Step implements Serializable {
         
         @Override
         public Set<Class<?>> getRequiredContext() {
-            return Sets.immutable.of(FlowNode.class, Run.class, TaskListener.class).castToSet();
+            return ImmutableSet.of(FlowNode.class, Run.class, TaskListener.class);
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/reporter/steps/PublishReportStep.java
+++ b/src/main/java/io/jenkins/plugins/reporter/steps/PublishReportStep.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.reporter.steps;
 
-import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
@@ -114,7 +113,7 @@ public class PublishReportStep extends Step implements Serializable {
         
         @Override
         public Set<Class<?>> getRequiredContext() {
-            return ImmutableSet.of(FlowNode.class, Run.class, TaskListener.class);
+            return Set.of(FlowNode.class, Run.class, TaskListener.class);
         }
 
         @Override


### PR DESCRIPTION
packaging a 10MiB library into the resulting hpi just to make use of immutable lists and sets seems a bit overkill.
Such things are available from plain Java nowadays.

This results in the hpi size to shrink from 12.9 MiB to 2.2 MiB

Also remove dependency to servlet-api which is provided by core

Still open is to replace the dependency to jackson with the api plugin as it currently doesn't include the dataformat-csv package (PR opened). This will shrink the hpi by another 2.1MiB resulting in a really lean plugin

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
