### PR TITLE
Fix: Set distribution list to full width

### DIFF
--- a/src/main/resources/report/distribution.jelly
+++ b/src/main/resources/report/distribution.jelly
@@ -59,16 +59,16 @@
                                     </j:forEach>
                                                                             
                                     <td>
-                                        <div>
+                                        <div class="d-flex">
                                              <j:forEach var="color" items="${row.colors}">
                                                 <j:set var="id" value="${color.key}"/>
                                                 <j:set var="hex" value="${row.getColor(id)}"/>
                                                 <j:set var="percentage" value="${row.getPercentage(id)}"/>
                                                 
                                                 <j:if test="${row.containsColorItem(id)}">
-                                                    <span id="tooltip-${row.id}-${id}" class="distribution" style="width: ${percentage}%; background-color: ${hex}"
+                                                    <span id="tooltip-${row.id}-${id}" style="width: ${percentage}%; background-color: ${hex}"
                                                           data-bs-toggle="tooltip" data-bs-placement="left" 
-                                                          title="${row.tooltip(id, percentage)}">.</span>
+                                                          title="${row.tooltip(id, percentage)}"></span>
                                                 </j:if>
                                                                                 
                                             </j:forEach>

--- a/src/main/webapp/css/custom-style.css
+++ b/src/main/webapp/css/custom-style.css
@@ -68,7 +68,7 @@
 }
 
 .distribution {
-    display: inline-block; 
+    display: block;
     color: transparent;
 }
 

--- a/src/main/webapp/css/custom-style.css
+++ b/src/main/webapp/css/custom-style.css
@@ -68,7 +68,7 @@
 }
 
 .distribution {
-    display: block;
+    display: inline-block;
     color: transparent;
 }
 


### PR DESCRIPTION
The distribution list was previously set to `display: inline-block`, which caused it to only take up as much width as its content. I've changed this to `display: block` to ensure it takes up the full available width.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
