### PR TITLE
Fix numeric sorting in distribution table

### DIFF
--- a/src/main/resources/report/distribution.jelly
+++ b/src/main/resources/report/distribution.jelly
@@ -46,7 +46,7 @@
                                     </td>
                                     
                                     <j:forEach var="i" items="${row.item.result}">
-                                        <td class="text-end">${row.label(i.key, i.value)}</td>
+                                        <td class="text-end" data-order="${i.value}" >${row.label(i.key, i.value)}</td>
                                     </j:forEach>
                                                                             
                                     <td>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #414

### Description

This PR fixes numeric sorting in the Distribution table.

before : sorted according to display text

```
1stTest__Bitbucket  1680	
2ndTestB            191456	
1stTest             51624	
2ndTestA            56220
```

after : sorted according to raw value

```
1stTest__Bitbucket  1680	
1stTest             51624	
2ndTestA            56220
2ndTestB            191456	
```

The fix adds a data-order attribute using the raw metric value in distribution.jelly, while keeping the displayed label unchanged.


### Testing done

<img width="1532" height="412" alt="image" src="https://github.com/user-attachments/assets/76b7792f-3659-4370-9425-72b31574ec0c" />

Ran `mvn verify` successfully.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
